### PR TITLE
add randgen subcommand

### DIFF
--- a/cmd/stmtflow/command/play.go
+++ b/cmd/stmtflow/command/play.go
@@ -11,11 +11,63 @@ import (
 	"github.com/zyguan/tidb-test-util/cmd/stmtflow/core"
 )
 
-func Play(c *CommonOptions) *cobra.Command {
-	var opts struct {
-		stmtflow.TextDumpOptions
-		Write bool
+type PlayOpts struct {
+	stmtflow.TextDumpOptions
+	Write bool
+}
+
+func GenResultFile(ctx context.Context, c *CommonOptions, path string, playOpts PlayOpts) error {
+	var (
+		in       io.ReadCloser
+		result   stmtflow.History
+		done     func()
+		evalOpts = c.EvalOptions()
+	)
+	db, err := c.OpenDB()
+	if err != nil {
+		return err
 	}
+	fmt.Printf("after open err=%v c.dsn=%v, path=%v\n", err, c.DSN, path)
+	in, err = os.Open(path)
+	if err != nil {
+		return err
+	}
+	if playOpts.Write {
+		textOut, err := os.OpenFile(resultPathForText(path), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+		if err != nil {
+			return err
+		}
+		jsonOut, err := os.OpenFile(resultPathForJson(path), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+		if err != nil {
+			return err
+		}
+		textWriter := stmtflow.TextDumper(io.MultiWriter(os.Stdout, textOut), playOpts.TextDumpOptions)
+		evalOpts.Callback = stmtflow.ComposeHandler(result.Collect, textWriter)
+		done = func() {
+			result.DumpJson(jsonOut, stmtflow.JsonDumpOptions{})
+			jsonOut.Close()
+			textOut.Close()
+			in.Close()
+			db.Close()
+		}
+	} else {
+		evalOpts.Callback = stmtflow.TextDumper(os.Stdout, playOpts.TextDumpOptions)
+		done = func() {
+			in.Close()
+			db.Close()
+		}
+	}
+
+	if err = stmtflow.Run(c.WithTimeout(ctx), db, core.ParseSQL(in), evalOpts); err != nil {
+		return err
+	}
+
+	done()
+	return nil
+}
+
+func Play(c *CommonOptions) *cobra.Command {
+	opts := PlayOpts{}
 	cmd := &cobra.Command{
 		Use:           "play [test.sql ...]",
 		Short:         "Try tests",
@@ -28,51 +80,10 @@ func Play(c *CommonOptions) *cobra.Command {
 			ctx := context.Background()
 			for _, path := range args {
 				fmt.Println("# " + path)
-				var (
-					in       io.ReadCloser
-					result   stmtflow.History
-					done     func()
-					evalOpts = c.EvalOptions()
-				)
-				db, err := c.OpenDB()
+				err := GenResultFile(ctx, c, path, opts)
 				if err != nil {
 					return err
 				}
-				in, err = os.Open(path)
-				if err != nil {
-					return err
-				}
-				if opts.Write {
-					textOut, err := os.OpenFile(resultPathForText(path), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-					if err != nil {
-						return err
-					}
-					jsonOut, err := os.OpenFile(resultPathForJson(path), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-					if err != nil {
-						return err
-					}
-					textWriter := stmtflow.TextDumper(io.MultiWriter(os.Stdout, textOut), opts.TextDumpOptions)
-					evalOpts.Callback = stmtflow.ComposeHandler(result.Collect, textWriter)
-					done = func() {
-						result.DumpJson(jsonOut, stmtflow.JsonDumpOptions{})
-						jsonOut.Close()
-						textOut.Close()
-						in.Close()
-						db.Close()
-					}
-				} else {
-					evalOpts.Callback = stmtflow.TextDumper(os.Stdout, opts.TextDumpOptions)
-					done = func() {
-						in.Close()
-						db.Close()
-					}
-				}
-
-				if err = stmtflow.Run(c.WithTimeout(ctx), db, core.ParseSQL(in), evalOpts); err != nil {
-					return err
-				}
-
-				done()
 			}
 			return nil
 		},

--- a/cmd/stmtflow/command/randgen.go
+++ b/cmd/stmtflow/command/randgen.go
@@ -90,7 +90,7 @@ func RandGen(c *CommonOptions) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&opts.caseName, "case_name", "sample_case", "case_name for the generated cases")
+	cmd.Flags().StringVarP(&opts.caseName, "case_name", "n", "sample_case", "case_name for the generated cases")
 	cmd.Flags().BoolVarP(&opts.withResults, "with_results", "r", false, "write to result file")
 	return cmd
 }

--- a/cmd/stmtflow/command/randgen.go
+++ b/cmd/stmtflow/command/randgen.go
@@ -1,0 +1,96 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/PingCAP-QE/clustered-index-rand-test/sqlgen"
+	"github.com/spf13/cobra"
+)
+
+const (
+	DropDBIfExistSQL = "/* init */ drop database if exists test;"
+	CreateDBIfNotExistSQL = "/* init */ create database if not exists test;"
+	UseDBSQL = "/* init */ use test;"
+)
+
+type options struct {
+	caseName    string
+	withResults bool
+}
+
+func genCase(basicPath string, initSQls []string, testSQLs []string, opts options) (string, error) {
+	testCaseFileName := filepath.Join(basicPath, opts.caseName+stdTestExt)
+	f, err := os.OpenFile(testCaseFileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "%s\n", DropDBIfExistSQL)
+	fmt.Fprintf(f, "%s\n", CreateDBIfNotExistSQL)
+	fmt.Fprintf(f, "%s\n", UseDBSQL)
+	for _, sql := range initSQls {
+		_, err = fmt.Fprintf(f, "/* init */ %s;\n", strings.TrimSpace(sql))
+		if err != nil {
+			return "", err
+		}
+	}
+	for _, sql := range testSQLs {
+		_, err = fmt.Fprintf(f, "/* s1 */ %s;\n", strings.TrimSpace(sql))
+		if err != nil {
+			return "", err
+		}
+	}
+	return testCaseFileName, nil
+}
+
+func RandGen(c *CommonOptions) *cobra.Command {
+	opts := options{}
+	cmd := &cobra.Command{
+		Use:           "randgen <case_name>",
+		Short:         "Generate rand test cases using cluster index rand gen",
+		SilenceErrors: true,
+		Args:          cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			state := sqlgen.NewState()
+			gen := sqlgen.NewGenerator(state)
+			count := 50
+			initSQLs := make([]string, 0, 50)
+			testSQLs := make([]string, 0, 50)
+			for state.IsInitializing() {
+				ss := gen()
+				for _, s := range strings.Split(ss, " ; ") {
+					initSQLs = append(initSQLs, s)
+				}
+			}
+
+			for i := 0; i < count; i++ {
+				ss := gen()
+				for _, s := range strings.Split(ss, " ; ") {
+					testSQLs = append(testSQLs, s)
+				}
+			}
+			path := args[0]
+			casePath, err := genCase(path, initSQLs, testSQLs, opts)
+			if err != nil {
+				return err
+			}
+			if opts.withResults {
+				ctx := context.Background()
+				playOps := PlayOpts{Write: true}
+				playOps.TextDumpOptions.Verbose = true
+				err = GenResultFile(ctx, c, casePath, playOps)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+	cmd.PersistentFlags().StringVar(&opts.caseName, "case_name", "sample_case", "case_name for the generated cases")
+	cmd.Flags().BoolVarP(&opts.withResults, "with_results", "r", false, "write to result file")
+	return cmd
+}

--- a/cmd/stmtflow/command/randgen.go
+++ b/cmd/stmtflow/command/randgen.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	DropDBIfExistSQL = "/* init */ drop database if exists test;"
+	DropDBIfExistSQL      = "/* init */ drop database if exists test;"
 	CreateDBIfNotExistSQL = "/* init */ create database if not exists test;"
-	UseDBSQL = "/* init */ use test;"
+	UseDBSQL              = "/* init */ use test;"
 )
 
 type options struct {
@@ -90,7 +90,7 @@ func RandGen(c *CommonOptions) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.PersistentFlags().StringVar(&opts.caseName, "case_name", "sample_case", "case_name for the generated cases")
+	cmd.Flags().StringVar(&opts.caseName, "case_name", "sample_case", "case_name for the generated cases")
 	cmd.Flags().BoolVarP(&opts.withResults, "with_results", "r", false, "write to result file")
 	return cmd
 }

--- a/cmd/stmtflow/command/root.go
+++ b/cmd/stmtflow/command/root.go
@@ -59,7 +59,7 @@ func Root() *cobra.Command {
 	cmd.PersistentFlags().DurationVar(&opts.PingTime, "ping-time", 200*time.Millisecond, "max wait time to ping a blocked statement")
 	cmd.PersistentFlags().DurationVar(&opts.BlockTime, "block-time", 9*time.Second, "max time to wait a newly submitted statement")
 
-	cmd.AddCommand(AutoGen(), Play(&opts), Test(&opts))
+	cmd.AddCommand(AutoGen(), Play(&opts), Test(&opts), RandGen(&opts))
 	cmd.AddCommand(&cobra.Command{
 		Use:   "version",
 		Short: "Show version information",

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
+	github.com/PingCAP-QE/clustered-index-rand-test v0.0.0-20210420063657-1a6ea6572739
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/google/go-jsonnet v0.17.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/PingCAP-QE/clustered-index-rand-test v0.0.0-20210420063657-1a6ea6572739 h1:tly59N+rC0IOIrpJh1lFIA/gI8nh7oVbVL7AOyjqc3U=
+github.com/PingCAP-QE/clustered-index-rand-test v0.0.0-20210420063657-1a6ea6572739/go.mod h1:2nmxkwSo99SXgjQyeGmCY6M4iaFwEgGk+ZD5cNOidDc=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -33,6 +35,8 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 h1:iwZdTE0PVqJCos1vaoKsclOGD3ADKpshg3SRtYBbwso=
+github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548/go.mod h1:e6NPNENfs9mPDVNRekM7lKScauxd5kXTr1Mfyig6TDM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -71,6 +75,7 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -156,6 +161,8 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 h1:OdAsTTz6OkFY5QxjkYwrChwuRruF69c169dPK26NUlk=
+github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -191,6 +198,7 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/zyguan/just v0.0.0-20200303164907-cac852552279/go.mod h1:6kWQwdxguAiSPj8OrHtKNLHR55qbZyHgVIa6xfKdoPA=
+github.com/zyguan/just v0.0.0-20201209133552-9791f5cd031c/go.mod h1:6kWQwdxguAiSPj8OrHtKNLHR55qbZyHgVIa6xfKdoPA=
 github.com/zyguan/sqlz v0.0.0-20210309141421-491a44ab6d63 h1:XB55M/Ry23ymwyrIeuwpi5pKpWcfRScxsFcr8TqRvHQ=
 github.com/zyguan/sqlz v0.0.0-20210309141421-491a44ab6d63/go.mod h1:AutAgtYwB095YomYO7uf7AESmwV0VfVdyt/4kXFV3l0=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -245,6 +253,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
https://github.com/zyguan/tidb-test-util/issues/6

Simply add a randgen subcommand to generate the test case in stmtflow format and result files, in this way the randgen is used as a library. The usage is like
```
./stmtflow randgen . -n test -r

The generated rand cases and results are like:
test.t.sql
test.r.sql
```

In the future we could 
- Extend the subcommand generation dissecting different randgen parameters, so that more deterministic and expected path could be covered for the cluster index feature. As the main paramters for the randgen is jost the weight config, we may still need to verify if the generation satisfy our needs. For example we want add a conflict update statement case which uses `pointGet` on clustered index to fetch value, we may still need to verify the generated sql statemtens.
- Add some abtest utility to verify the newly generated cases.